### PR TITLE
Python3 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 iso8601utils==0.1.2
 requests==2.13.0
+six==1.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+iso8601utils==0.1.2
+requests==2.13.0

--- a/tagme/__init__.py
+++ b/tagme/__init__.py
@@ -4,9 +4,10 @@ This module provides a wrapper for the TagMe API.
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import json
 import logging
 import requests
-import json
+import six
 
 from iso8601utils import parsers
 
@@ -234,10 +235,10 @@ def _relatedness(pairs_type, pairs, gcube_token, lang, api):
     if not isinstance(pairs[0], (list, tuple)):
         pairs = [pairs]
 
-    if hasattr(pairs[0][0], "decode"):  # bytestring in python 2 or 3
+    if isinstance(pairs[0][0], six.binary_type):  # str in python 2, bytes in python 3
         pairs = [(p[0].decode("utf-8"), p[1].decode("utf-8")) for p in pairs]
 
-    if hasattr(pairs[0][0], "encode"):  # unicode string in python 2 or 3
+    if isinstance(pairs[0][0], six.text_type):  # unicode in python 2, str in python 3
         pairs = [(normalize_title(p[0]), normalize_title(p[1])) for p in pairs]
 
     json_responses = []
@@ -262,5 +263,5 @@ def _issue_request(api, payload, gcube_token):
     if res.status_code != 200:
         logging.warning("Tagme returned status code %d message:\n%s", res.status_code, res.content)
         return None
-    res_content = res.content.decode("utf-8") if hasattr(res.content, "decode") else res.content
+    res_content = res.content.decode("utf-8") if isinstance(res.content, six.binary_type) else res.content
     return json.loads(res_content)

--- a/tests/test_calls.py
+++ b/tests/test_calls.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import sys
 import tagme
 
@@ -5,48 +7,48 @@ SAMPLE_TEXT = "Obama visited uk"
 
 def main():
     # Annotate a text.
-    print "Annotating text: ", SAMPLE_TEXT
+    print("Annotating text: ", SAMPLE_TEXT)
     resp = tagme.annotate(SAMPLE_TEXT)
-    print resp
+    print(resp)
     for ann in resp.annotations:
-        print ann
+        print(ann)
 
     # Find mentions in a text.
-    print "Finding mentions in text: ", SAMPLE_TEXT
+    print("Finding mentions in text: ", SAMPLE_TEXT)
     resp = tagme.mentions(SAMPLE_TEXT)
-    print resp
+    print(resp)
     for mention in resp.mentions:
-        print mention
+        print(mention)
 
     # Find relatedness between one pair of entities, by title.
     resp = tagme.relatedness_title(["Barack_Obama", "Italy"])
-    print resp
+    print(resp)
     for rel in resp.relatedness:
-        print rel
+        print(rel)
 
     # Find relatedness between pairs of entities, by title.
     resp = tagme.relatedness_title([("Barack_Obama", "Italy"),
                                 ("Italy", "Germany"),
                                 ("Italy", "BAD ENTITY NAME")])
-    print resp
+    print(resp)
     for rel in resp.relatedness:
-        print rel
+        print(rel)
 
     # Access the relatedness response as a dictionary.
     resp_dict = dict(resp)
-    print "Relatedness between Italy and Germany: ", resp_dict[("Italy", "Germany")]
+    print("Relatedness between Italy and Germany: ", resp_dict[("Italy", "Germany")])
 
     # Find relatedness between one pair of entities, by wikipedia id
     resp = tagme.relatedness_wid((31717, 534366))
-    print resp
+    print(resp)
     for rel in resp.relatedness:
-        print rel
+        print(rel)
 
     # Find relatedness between pairs of entities, by wikipedia id
     resp = tagme.relatedness_wid([(534366, 534366 + a) for a in range (1010)])
-    print resp
+    print(resp)
     for rel in resp.relatedness:
-        print rel
+        print(rel)
 
 if __name__ == "__main__":
     tagme.GCUBE_TOKEN = sys.argv[1]


### PR DESCRIPTION
This Pull Request adds Python 3 support (and also adds a `requirements.txt` file).

The main change is when the code checks `isinstance(pairs[0][0], (str, unicode))`, which does not work in Python 3.  I fixed this using the `six` module which is pretty much preinstalled everywhere.

I also added a `requirements.txt` to make it clear what the dependencies are.